### PR TITLE
[core/types] Create GenerateBLSKey helper

### DIFF
--- a/core/types/receipt_test.go
+++ b/core/types/receipt_test.go
@@ -26,6 +26,7 @@ import (
 	"testing"
 
 	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
 	"github.com/ethereum/go-ethereum/params"
 	"github.com/ethereum/go-ethereum/rlp"
 	"github.com/holiman/uint256"
@@ -157,7 +158,7 @@ var (
 		Type: DepositTxType,
 	}
 
-	k, _ = newKey()
+	k, _ = crypto.GenerateBLSKey()
 
 	// Create a few transactions to have receipts for
 	to2 = common.HexToAddress("0x2")
@@ -225,7 +226,7 @@ var (
 			BlobFeeCap: uint256.NewInt(100077),
 			BlobHashes: []common.Hash{{}, {}, {}},
 		}),
-		NewTx(k.createEmptyBLSTxInner(8)),
+		NewTx(createEmptyBLSTxInner(8, k)),
 		NewTx(&DepositTx{
 			To:    nil, // contract creation
 			Value: big.NewInt(6),

--- a/core/types/transaction_signing_test.go
+++ b/core/types/transaction_signing_test.go
@@ -176,12 +176,12 @@ func TestNilSigner(t *testing.T) {
 			})
 			// test BLS tx because the signature scheme is different
 			t.Run("blstx", func(t *testing.T) {
-				k, err := newKey()
+				k, err := crypto.GenerateBLSKey()
 				if err != nil {
 					t.Fatal("error creating key")
 				}
-				blstx := k.createEmptyBLSTxInner(5)
-				ecdsaPrivKey, err := crypto.BLSToECDSA(k.sk)
+				blstx := createEmptyBLSTxInner(5, k)
+				ecdsaPrivKey, err := crypto.BLSToECDSA(k)
 				if err != nil {
 					t.Fatal("error converting BLS to ECDSA private key:", err)
 				}

--- a/crypto/crypto.go
+++ b/crypto/crypto.go
@@ -104,6 +104,16 @@ func Keccak512(data ...[]byte) []byte {
 	return d.Sum(nil)
 }
 
+// Create a new BLS public and secret key. This should
+// only be used for testing.
+func GenerateBLSKey() (*bls.SecretKey, error) {
+	sk, err := bls.NewSecretKey()
+	if err != nil {
+		return nil, err
+	}
+	return sk, nil
+}
+
 // Both the BLS and ECDSA private key uses random 32 bytes. Therefore, we can
 // have these 32 bytes represent 2 different account types (BLS and ECDSA).
 //


### PR DESCRIPTION
Introduces `GenerateBLSKey` into the `crypto` package. This is helpful for providing a higher level library helper that can be used outside of just `core/types` (i.e., writing a test in `eth/catalyst/api.go` to test block building)